### PR TITLE
Fixed segfault from gROOT.SetBatch with argparse

### DIFF
--- a/analyzers/AnalyzerBase.py
+++ b/analyzers/AnalyzerBase.py
@@ -34,9 +34,10 @@ from pu_weights import PileupWeights
 import leptonId as lepId
 from ntuples import *
 
+sys.argv.append('-b')
 import ROOT as rt
+sys.argv.pop()
 
-rt.gROOT.SetBatch(rt.kTRUE)
 
 ZMASS = 91.1876
 


### PR DESCRIPTION
I'm not entirely sure how it happens, but the gROOT.SetBatch() function
results in a segfault coming from the cmssw /lib/ROOT.py file when used in tandem with the argparse module.
Adding "-b-" to argv is an equivalent way to enter root batch mode that
does not cause this error.
